### PR TITLE
Replace dummy AWS account ids

### DIFF
--- a/custodian/policies/cloudtrail/test-event/README.md
+++ b/custodian/policies/cloudtrail/test-event/README.md
@@ -1,5 +1,5 @@
 # Detect Root Login - test event
 * In the console, browse to the Lambda function "custodian-root-user-login-detected"
 * Create a test event of type Amazon CloudWatch
-* Paste in the contents of the JSON file in this directory
+* Paste in the contents of the JSON file in this directory, replacing all the `some_account_id` instances with a dummy AWS account ID (12 digits)
 * Press Test

--- a/custodian/policies/cloudtrail/test-event/detect-root-logins-test-event.json
+++ b/custodian/policies/cloudtrail/test-event/detect-root-logins-test-event.json
@@ -3,7 +3,7 @@
   "id": "6f87d04b-9f74-4f04-a780-7acf4b0a9b38",
   "detail-type": "AWS Console Sign In via CloudTrail",
   "source": "aws.signin",
-  "account": "123456789012",
+  "account": "some_account_id",
   "time": "2016-01-05T18:21:27Z",
   "region": "us-east-1",
   "resources": [],
@@ -12,8 +12,8 @@
     "userIdentity": {
       "type": "Root",
       "principalId": "123456789012",
-      "arn": "arn:aws:iam::123456789012:root",
-      "accountId": "123456789012"
+      "arn": "arn:aws:iam::some_account_id:root",
+      "accountId": "some_account_id"
     },
     "eventTime": "2016-01-05T18:21:27Z",
     "eventSource": "signin.amazonaws.com",

--- a/custodian/policies/guardduty/test-event/README.md
+++ b/custodian/policies/guardduty/test-event/README.md
@@ -3,7 +3,7 @@
 ## TEST
 * create a test event for the custodian-guard-duty-notify lambda function
 * copy the contents of crypto-test-event.json into the test event template
-* replace the Account ID and Guard Duty detector ID with real values
+* replace the instances of `some_account_id` and Guard Duty detector ID with real values
 * create an EC2 instance in the same region as the GuardDuty master account
 * replace the instance ID in the test event with the real instance ID
 * test the lambda function using the newly created test event

--- a/custodian/policies/guardduty/test-event/crypto-test-event.json
+++ b/custodian/policies/guardduty/test-event/crypto-test-event.json
@@ -3,24 +3,24 @@
   "id": "1c1ef4fd-8405-c87a-d65d-015d332619f6",
   "detail-type": "GuardDuty Finding",
   "source": "aws.guardduty",
-  "account": "012345678901",
+  "account": "some_account_id",
   "time": "2020-04-20T14:45:06Z",
   "region": "eu-west-2",
   "resources": [],
   "detail": {
     "schemaVersion": "2.0",
-    "accountId": "012345678901",
+    "accountId": "some_account_id",
     "region": "eu-west-2",
     "partition": "aws",
     "id": "d8b8cbf6ed25f5adc5491ee4dd24a92b",
-    "arn": "arn:aws:guardduty:eu-west-2:012345678901:detector/abcdefg01234567890abcdefg01234567890/finding/d8b8cbf6ed25f5adc5491ee4dd24a92b",
+    "arn": "arn:aws:guardduty:eu-west-2:some_account_id:detector/abcdefg01234567890abcdefg01234567890/finding/d8b8cbf6ed25f5adc5491ee4dd24a92b",
     "type": "CryptoCurrency:EC2/BitcoinTool.B",
     "resource": {
       "resourceType": "Instance",
       "instanceDetails": {
         "instanceId": "i-99999999",
         "instanceType": "m3.xlarge",
-        "outpostArn": "arn:aws:outposts:us-west-2:123456789000:outpost/op-0fbc006e9abbc73c3",
+        "outpostArn": "arn:aws:outposts:us-west-2:some_account_id:outpost/op-0fbc006e9abbc73c3",
         "launchTime": "2016-08-02T02:05:06Z",
         "platform": null,
         "productCodes": [


### PR DESCRIPTION
Dummy account ids were getting picked up by GitSecrets

Replaced with consistent string value so can be replaced as needed

Updated instructions for using the test json