### PR TITLE
Set single S3 lambda to run in VPC

### DIFF
--- a/accounts/tdr-mgmt-deploy.sh
+++ b/accounts/tdr-mgmt-deploy.sh
@@ -4,8 +4,11 @@
 ENVIRONMENT="mgmt"
 OWNER="TDR"
 TO_ADDRESS="tdr-secops@nationalarchives.gov.uk"
+#only retrieve the private subnets
+SUBNETS=$(aws ec2 describe-subnets --filters Name=tag:Name,Values=*-private-* | jq '.Subnets[].SubnetId')
+SECURITY_GROUPS=$(aws ec2 describe-security-groups | jq '.SecurityGroups[].GroupId')
 
 echo "Cloud Custodian will now deploy to $OWNER $ENVIRONMENT. You have 5 seconds to Ctrl-C"
 sleep 5
 
-../custodian/scripts/deploy-custodian.sh "$ENVIRONMENT" "$OWNER" "$TO_ADDRESS"
+../custodian/scripts/deploy-custodian.sh "$ENVIRONMENT" "$OWNER" "$TO_ADDRESS" "$SUBNETS" "$SECURITY_GROUPS"

--- a/custodian/policies/s3/s3-check-public-block-policy.yml
+++ b/custodian/policies/s3/s3-check-public-block-policy.yml
@@ -4,8 +4,6 @@ policies:
       type: periodic
       schedule: "rate(1 hour)"
       role: arn:aws:iam::{account_id}:role/CustodianS3CheckPublicBlock
-      subnets: {subnets}
-      security_groups: {security_groups}
     resource: aws.s3
     description: |
       Scans all S3 buckets for public access block and sets block if not present

--- a/custodian/policies/s3/s3-check-public-block-policy.yml
+++ b/custodian/policies/s3/s3-check-public-block-policy.yml
@@ -4,6 +4,8 @@ policies:
       type: periodic
       schedule: "rate(1 hour)"
       role: arn:aws:iam::{account_id}:role/CustodianS3CheckPublicBlock
+      subnets: {subnets}
+      security_groups: {security_groups}
     resource: aws.s3
     description: |
       Scans all S3 buckets for public access block and sets block if not present

--- a/custodian/scripts/build-policy-yml.py
+++ b/custodian/scripts/build-policy-yml.py
@@ -2,8 +2,15 @@ from pathlib import Path
 from ruamel.yaml import YAML
 import argparse
 
+def get_id_list_from_string(s):
+    if len(s) == 0:
+        return []
+    else:
+        ids = s.replace('"', '').split('\n')
+        return ids
+
 class policy:
-    def __init__(self, cost_centre, environment, filepath, name, owner, slack_webhook, to_address, sqs_region, sqs_account):
+    def __init__(self, cost_centre, environment, filepath, name, owner, slack_webhook, to_address, sqs_region, sqs_account, subnets, security_groups):
         self.cost_centre = cost_centre
         self.environment = environment
         self.filepath = filepath
@@ -13,6 +20,8 @@ class policy:
         self.to_address = to_address
         self.sqs_region = sqs_region
         self.sqs_account = sqs_account
+        self.subnets = subnets
+        self.security_groups = security_groups
 
         path = Path(filepath)
         opath = Path('deploy.yml')
@@ -22,6 +31,8 @@ class policy:
             code = yaml.load(path)
             yaml.indent(mapping=2, sequence=4, offset=2)
             code['policies'][0]['mode']['tags'] = dict(CostCentre=cost_centre, Environment=environment, Name=name, Owner=owner)
+            if len(security_groups) > 0: code['policies'][0]['mode']['security_groups'] = security_groups
+            if len(subnets) > 0: code['policies'][0]['mode']['subnets'] = subnets
             code['policies'][0]['actions'][0]['to'][0] = to_address
             code['policies'][0]['actions'][1]['to'][1] = 'https://hooks.slack.com/services/' + slack_webhook
             code['policies'][0]['actions'][0]['transport']['queue'] = 'https://sqs.' + sqs_region + '.amazonaws.com/' + sqs_account + '/custodian-mailer'
@@ -40,6 +51,8 @@ if __name__ == "__main__":
     parser.add_argument('--to_address', required=True)
     parser.add_argument('--sqs_region', required=True)
     parser.add_argument('--sqs_account', default="{account_id}")
+    parser.add_argument('--subnets', default='')
+    parser.add_argument('--security_groups', default='')
 
     args = parser.parse_args()
 
@@ -52,5 +65,7 @@ if __name__ == "__main__":
     to_address = args.to_address
     sqs_region = args.sqs_region
     sqs_account = args.sqs_account
+    subnets = get_id_list_from_string(args.subnets)
+    security_groups = get_id_list_from_string(args.security_groups)
 
-    policy(cost_centre, environment, filepath, name, owner, slack_webhook, to_address, sqs_region, sqs_account)
+    policy(cost_centre, environment, filepath, name, owner, slack_webhook, to_address, sqs_region, sqs_account, subnets, security_groups)

--- a/custodian/scripts/deploy-custodian.sh
+++ b/custodian/scripts/deploy-custodian.sh
@@ -9,7 +9,7 @@ CUSTODIAN_REGION_1="eu-west-2"
 CUSTODIAN_REGION_2="eu-west-1"
 SES_REGION="eu-west-2"
 SQS_ACCOUNT=$(aws sts get-caller-identity | jq '.Account' | tr -d '"')
-SUBNETS=$(aws ec2 describe-subnets | jq '[.Subnets[].SubnetId]')
+SUBNETS=$(aws ec2 describe-subnets --filters Name=tag:Name,Values=*-private-* | jq '[.Subnets[].SubnetId]')
 SECURITY_GROUPS=$(aws ec2 describe-security-groups | jq '[.SecurityGroups[].GroupId]')
 
 echo "Configuring mailer"

--- a/terraform/modules/iam/common-policies.tf
+++ b/terraform/modules/iam/common-policies.tf
@@ -2,3 +2,8 @@ resource "aws_iam_policy" "lambda_common_policy" {
   name   = "${upper(var.project)}CustodianLambdaCommon${title(local.environment)}"
   policy = templatefile("./modules/iam/templates/common/lambda_common_policy.json.tpl", {})
 }
+
+resource "aws_iam_policy" "lambda_vpc_access_execution" {
+  name   = "${upper(var.project)}CustondialLambdaVpcAccessExecution${title(local.environment)}"
+  policy = templatefile("./modules/iam/templates/common/lambda_vpc_access_execution.json.tpl", {})
+}

--- a/terraform/modules/iam/s3_check_public_block.tf
+++ b/terraform/modules/iam/s3_check_public_block.tf
@@ -10,6 +10,12 @@ resource "aws_iam_role_policy_attachment" "s3_check_public_block_common_policy_a
   policy_arn = aws_iam_policy.lambda_common_policy.*.arn[0]
 }
 
+resource "aws_iam_role_policy_attachment" "s3_check_public_block_vpc_execution_access" {
+  count      = var.s3_check_public_block == true ? 1 : 0
+  role       = aws_iam_role.s3_check_public_block_assume_role.*.name[0]
+  policy_arn = aws_iam_policy.lambda_vpc_access_execution.*.arn[0]
+}
+
 resource "aws_iam_policy" "s3_check_public_block_policy" {
   count  = var.s3_check_public_block == true ? 1 : 0
   name   = "${upper(var.project)}CustodianS3CheckPublicBlock${title(local.environment)}"

--- a/terraform/modules/iam/templates/common/lambda_vpc_access_execution.json.tpl
+++ b/terraform/modules/iam/templates/common/lambda_vpc_access_execution.json.tpl
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "ec2:CreateNetworkInterface",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DeleteNetworkInterface",
+                "ec2:AssignPrivateIpAddresses",
+                "ec2:UnassignPrivateIpAddresses"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
For security S3 IP restriction policy is set on the TDR Export S3 bucket

To continue to allow the S3 custodian policies to run against the IP restricted buckets need to run the custodian lambdas in the relevant VPC: https://cloudcustodian.io/docs/tools/c7n-mailer.html?highlight=security_group#standard-lambda-function-config

Other S3 Custodian lambdas to be updated in other commits