### PR TITLE
DR2-1651 Add inspector notifications.

### DIFF
--- a/custodian/policies/inspector/inspector-findings.yml
+++ b/custodian/policies/inspector/inspector-findings.yml
@@ -1,0 +1,18 @@
+policies:
+  - name: inspector-findings-policy
+    resource: aws.inspector2-finding
+    mode:
+        type: periodic
+        schedule: "rate(1 day)"
+        role: arn:aws:iam::{account_id}:role/CustodianInspectorFindings
+        tags: {tags}
+    actions:
+      - type: notify
+        slack_template: slack_inspector
+        violation_desc: 'Account {account_id} Inspector has found vulnerabilities'
+        to:
+          - slack://webhook/#mfa-warn
+          - {slack_webhook}
+        transport:
+          type: sqs
+          queue: https://sqs.{region}.amazonaws.com/{account_id}/custodian-mailer

--- a/custodian/policies/inspector/inspector-findings.yml
+++ b/custodian/policies/inspector/inspector-findings.yml
@@ -9,7 +9,7 @@ policies:
     actions:
       - type: notify
         slack_template: slack_inspector
-        violation_desc: 'Account {account_id} Inspector has found vulnerabilities'
+        violation_desc: 'Amazon Inspector has found vulnerabilities in account {account_id}'
         to:
           - slack://webhook/#mfa-warn
           - {slack_webhook}

--- a/custodian/scripts/build-policy-yml.py
+++ b/custodian/scripts/build-policy-yml.py
@@ -23,10 +23,11 @@ class policy:
             yaml.indent(mapping=2, sequence=4, offset=2)
             code['policies'][0]['mode']['tags'] = dict(CostCentre=cost_centre, Environment=environment, Name=name, Owner=owner)
             actions = code['policies'][0]['actions']
-            queue_url = 'https://sqs.' + sqs_region + '.amazonaws.com/' + sqs_account + '/custodian-mailer'
+            queue_url = f'https://sqs.{sqs_region}.amazonaws.com/{sqs_account}/custodian-mailer'
             for action in actions:
                 action['transport']['queue'] = queue_url
-            if len(actions) == 2:
+            email_and_slack_action = len(actions) == 2
+            if email_and_slack_action:
                 actions[0]['to'][0] = to_address
                 actions[1]['to'][1] = slack_webhook
             else:

--- a/custodian/scripts/build-policy-yml.py
+++ b/custodian/scripts/build-policy-yml.py
@@ -22,10 +22,17 @@ class policy:
             code = yaml.load(path)
             yaml.indent(mapping=2, sequence=4, offset=2)
             code['policies'][0]['mode']['tags'] = dict(CostCentre=cost_centre, Environment=environment, Name=name, Owner=owner)
-            code['policies'][0]['actions'][0]['to'][0] = to_address
-            code['policies'][0]['actions'][1]['to'][1] = slack_webhook
-            code['policies'][0]['actions'][0]['transport']['queue'] = 'https://sqs.' + sqs_region + '.amazonaws.com/' + sqs_account + '/custodian-mailer'
-            code['policies'][0]['actions'][1]['transport']['queue'] = 'https://sqs.' + sqs_region + '.amazonaws.com/' + sqs_account + '/custodian-mailer'
+            actions = code['policies'][0]['actions']
+            queue_url = 'https://sqs.' + sqs_region + '.amazonaws.com/' + sqs_account + '/custodian-mailer'
+            for action in actions:
+                action['transport']['queue'] = queue_url
+            if len(actions) == 2:
+                actions[0]['to'][0] = to_address
+                actions[1]['to'][1] = slack_webhook
+            else:
+                actions[0]['to'][1] = slack_webhook
+
+
             yaml.dump(code)
 
 if __name__ == "__main__":

--- a/custodian/scripts/deploy-custodian.sh
+++ b/custodian/scripts/deploy-custodian.sh
@@ -146,3 +146,7 @@ then
   python ../custodian/scripts/build-policy-yml.py --cost_centre "$COST_CENTRE" --environment "$ENVIRONMENT" --filepath "../custodian/policies/dynamodb/reference-counter/reference-counter-table-pitr-check.yml" --owner "$OWNER" --slack_webhook "$SLACK_WEBHOOK" --to_address "$TO_ADDRESS" --sqs_region "$SES_REGION" --sqs_account "$SQS_ACCOUNT"
   custodian run -s logs --region="$CUSTODIAN_REGION_1" deploy.yml
 fi
+
+echo "Deploying Inspector2 findings block"
+python ../custodian/scripts/build-policy-yml.py --cost_centre "$COST_CENTRE" --environment "$ENVIRONMENT" --filepath "../custodian/policies/inspector/inspector-findings.yml" --owner "$OWNER" --slack_webhook "$SLACK_WEBHOOK" --to_address "$TO_ADDRESS" --sqs_region "$SES_REGION" --sqs_account "$SQS_ACCOUNT"
+custodian run -s logs --region="$CUSTODIAN_REGION_1" deploy.yml

--- a/custodian/templates/slack_inspector.j2
+++ b/custodian/templates/slack_inspector.j2
@@ -1,0 +1,39 @@
+{
+   "attachments":[
+      {
+         "fallback":"Cloud Custodian Policy Violation",
+         "title":"Custodian",
+         "color":"{{ action['slack_msg_color']|default("danger") }}",
+         "fields":[
+            {
+               "title":"Resources",
+               "value":"{%- for resource in resources -%}
+                            {%- for findingResource in resource['resources'] -%}
+                                *{{ findingResource['details']['awsEcrContainerImage']['repositoryName'] }}: {{ findingResource['details']['awsEcrContainerImage']['imageTags']|join(',') }}*: {{ resource['title'] }} Severity {{ resource['severity'] }}\n
+                            {%- endfor -%}
+                        {%- endfor -%}"
+            },
+            {
+               "title":"Account",
+               "value":"{{ account_id }}"
+            },
+            {
+               "title":"Region",
+               "value":"{{ region }}"
+            },
+            {
+               "title":"Violation Description",
+               "value":"{{ action['violation_desc'] }}"
+            },
+            {
+               "title":"Action Description",
+               "value":"{{ action['action_desc'] }}"
+            }
+         ]
+      }
+   ],
+   {%- if not recipient.startswith('https://') %}
+   "channel":"{{ recipient }}",
+   {%- endif -%}
+   "username":"Custodian"
+}

--- a/terraform/modules/iam/inspector_findings.tf
+++ b/terraform/modules/iam/inspector_findings.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_role_policy_attachment" "inspector_lambda_common_policy_attach" {
+  count      = var.inspector == true ? 1 : 0
+  role       = aws_iam_role.inspector_assume_role.*.name[0]
+  policy_arn = aws_iam_policy.lambda_common_policy.*.arn[0]
+}
+
+resource "aws_iam_role" "inspector_assume_role" {
+  count              = var.inspector == true ? 1 : 0
+  name               = "CustodianInspectorFindings"
+  assume_role_policy = templatefile("./modules/iam/templates/common/assume_role_policy.json.tpl", {})
+}
+
+resource "aws_iam_policy" "inspector_policy" {
+  count  = var.inspector == true ? 1 : 0
+  name   = "${upper(var.project)}CustodianInspectorFindings${title(local.environment)}"
+  policy = templatefile("./modules/iam/templates/custom/inspector_policy.json.tpl", {})
+}
+
+resource "aws_iam_role_policy_attachment" "inspector_policy_attach" {
+  count      = var.inspector == true ? 1 : 0
+  role       = aws_iam_role.inspector_assume_role.*.name[0]
+  policy_arn = aws_iam_policy.inspector_policy.*.arn[0]
+}

--- a/terraform/modules/iam/inspector_findings.tf
+++ b/terraform/modules/iam/inspector_findings.tf
@@ -1,23 +1,28 @@
+locals {
+  inspector_count      = var.inspector == true ? 1 : 0
+  inspector_role_name  = aws_iam_role.inspector_assume_role.*.name[0]
+  inspector_policy_arn = aws_iam_policy.inspector_policy.*.arn[0]
+}
 resource "aws_iam_role_policy_attachment" "inspector_lambda_common_policy_attach" {
-  count      = var.inspector == true ? 1 : 0
-  role       = aws_iam_role.inspector_assume_role.*.name[0]
-  policy_arn = aws_iam_policy.lambda_common_policy.*.arn[0]
+  count      = local.inspector_count
+  role       = local.inspector_role_name
+  policy_arn = local.inspector_policy_arn
 }
 
 resource "aws_iam_role" "inspector_assume_role" {
-  count              = var.inspector == true ? 1 : 0
+  count              = local.inspector_count
   name               = "CustodianInspectorFindings"
   assume_role_policy = templatefile("./modules/iam/templates/common/assume_role_policy.json.tpl", {})
 }
 
 resource "aws_iam_policy" "inspector_policy" {
-  count  = var.inspector == true ? 1 : 0
+  count  = local.inspector_count
   name   = "${upper(var.project)}CustodianInspectorFindings${title(local.environment)}"
   policy = templatefile("./modules/iam/templates/custom/inspector_policy.json.tpl", {})
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_policy_attach" {
-  count      = var.inspector == true ? 1 : 0
-  role       = aws_iam_role.inspector_assume_role.*.name[0]
-  policy_arn = aws_iam_policy.inspector_policy.*.arn[0]
+  count      = local.inspector_count
+  role       = local.inspector_role_name
+  policy_arn = local.inspector_policy_arn
 }

--- a/terraform/modules/iam/templates/custom/inspector_policy.json.tpl
+++ b/terraform/modules/iam/templates/custom/inspector_policy.json.tpl
@@ -1,0 +1,11 @@
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "InspectorListFindings",
+			"Effect": "Allow",
+			"Action": "inspector2:ListFindings",
+			"Resource": "*"
+		}
+	]
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -122,6 +122,6 @@ variable "reference_counter_check" {
 }
 
 variable "inspector" {
-  description = "The role for retrieving AWS inspector findings"
+  description = "Whether or not to create a role for retrieving AWS inspector findings"
   default     = true
 }

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -120,3 +120,8 @@ variable "reference_counter_check" {
   description = "The IAM role for checking DynamoDb reference counter table"
   default     = true
 }
+
+variable "inspector" {
+  description = "The role for retrieving AWS inspector findings"
+  default     = true
+}


### PR DESCRIPTION
I've had to add in a custom template because there's no default pretty
print for inspector like there is for other services.

I've also updated the python script which builds the custodian yaml
because it was assuming there was always an email and a slack notify
action which is annoying. We don't want to send an email.
